### PR TITLE
fix(swap): allow decimal input for amount

### DIFF
--- a/src/app/(walletConnected)/swap/page.tsx
+++ b/src/app/(walletConnected)/swap/page.tsx
@@ -193,7 +193,8 @@ export default function Swap() {
 	const userInputAmount = Number(amountIn) || 0
 	const userTokenBalance = mintABalance / Math.pow(10, fromTokenProps.decimals)
 	const isBaseTokenBalanceNotEnough = userInputAmount > userTokenBalance
-	const isAmountPositive = REGEX.POSITIVE_NUMBER.test(amountIn) && userInputAmount > 0
+	// Allow positive decimals for swap input
+	const isAmountPositive = REGEX.POSITIVE_DECIMAL.test(amountIn) && userInputAmount > 0
 	const hasValidTokenPair = fromTokenProps.address !== toTokenProps.address
 	const isValid =
 		!isBaseTokenBalanceNotEnough && isAmountPositive && hasValidTokenPair && canSwapQuery.data === true && swapQuote

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -1,5 +1,8 @@
 const REGEX = {
+	// Positive integer (no decimals)
 	POSITIVE_NUMBER: /^\d+$/,
+	// Positive decimal number, allows integers and decimals like 0.1, 3.326659
+	POSITIVE_DECIMAL: /^(?:\d+)(?:\.\d+)?$/,
 	ZERO_TO_TWELVE_RANGE: /^(0|[1-9]|1[0-2])$/,
 	ZERO_POINT_ZERO_FIVE_TO_FIFTY_RANGE: /^(?:0\.(?:0[5-9]|[1-9]\d?)|[1-9](?:\.\d+)?|[1-4]\d(?:\.\d+)?|50(?:\.0+)?)$/
 } as const


### PR DESCRIPTION
- Add REGEX.POSITIVE_DECIMAL for decimal-friendly validation
- Use POSITIVE_DECIMAL for isAmountPositive on swap page
- Keep existing POSITIVE_NUMBER for fields that must be integers